### PR TITLE
Letters to runes: handle not found characters

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,10 +6,12 @@ const transform = (content: string, dictionary: Map<string, string>) : string =>
   const parts: string[] = content.split('');
 
   parts.forEach((part) => {
-    if (dictionary.has(part)) {
-      result += dictionary.get(part);
-    } else if (part === ' ') {
-      result += ' ';
+    const partKey = part.toLocaleLowerCase();
+
+    if (dictionary.has(partKey)) {
+      result += dictionary.get(partKey);
+    } else {
+      result += part;
     }
   });
 

--- a/tests/letters-to-runes.test.ts
+++ b/tests/letters-to-runes.test.ts
@@ -1,13 +1,12 @@
 import youngerFuthark from '../src';
 
 describe('Letters to runes transformation tests', () => {
-  test('Ignores not-found letters', () => {
-    const falseLetters = '12345';
-    const expected = '';
+  test('Does not transform not-found characters', () => {
+    const original = '12345';
 
-    const result = youngerFuthark.lettersToRunes(falseLetters);
+    const result = youngerFuthark.lettersToRunes(original);
 
-    expect(result).toBe(expected);
+    expect(result).toBe(original);
   });
 
   test('Transforms letters to runes', () => {
@@ -29,6 +28,16 @@ describe('Letters to runes transformation tests', () => {
     expect(result).toBe(expected);
   });
 
+  test('Transforms upper & lowercase to same runes', () => {
+    // From Old Groms runestone.
+    const letters = 'AUK tani Karþi kriSTnA';
+    const expected = 'ᛅᚢᚴ ᛏᛅᚾᛁ ᚴᛅᚱᚦᛁ ᚴᚱᛁᛋᛏᚾᛅ';
+
+    const result = youngerFuthark.lettersToRunes(letters);
+
+    expect(result).toBe(expected);
+  });
+
   test('Transforms accented letters', () => {
     const letters = 'a e i o u y';
     const accentedLetters = 'á é í ó ú ý';
@@ -37,5 +46,13 @@ describe('Letters to runes transformation tests', () => {
     const result2 = youngerFuthark.lettersToRunes(accentedLetters);
 
     expect(result1).toEqual(result2);
+  });
+
+  test('Leaves non-matched letters unchanged.', () => {
+    const expected = 'ᛅᚾᛏ ᛚᚢ; "ᚼᛁ" ᛋᛒᚢᚴᛁ ᛁᚾ ᚱᛁᛏᛏᛚᛁᛋ.';
+
+    const result = youngerFuthark.lettersToRunes('And lo; "he" spoke in riddles.');
+
+    expect(result).toEqual(expected);
   });
 });


### PR DESCRIPTION
Returns ‘as-is”, as most of these are things like commas, periods or other non-transformable signs.

Fixes #12